### PR TITLE
fix build on non-glibc Linux

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -16,7 +16,7 @@
 #define stat64 __stat64
 #endif
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || !defined (__GLIBC__)
 #define stat64 stat
 #endif
 


### PR DESCRIPTION
* non-glibc Linux do not have stat64, causing build to fail on e.g. musl/Alpine.
* this commit adds a check to make sure we are on a glibc system before using stat64.